### PR TITLE
Profile Page UI

### DIFF
--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -32,7 +32,7 @@ html:focus-within {
 
 html,
 body {
-  height: 100%;
+  /* height: 100%; */
   background-color: #E8EADF;
 }
 
@@ -44,7 +44,7 @@ body {
 
 /* A elements that don't have a class get default styles */
 a {
-    color: inherit; 
+    color: inherit;
     text-decoration: inherit;
 }
 
@@ -65,7 +65,7 @@ svg {
   html:focus-within {
    scroll-behavior: auto;
   }
-  
+
   *,
   *::before,
   *::after {

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -4,10 +4,11 @@ import {
 } from 'react-router-dom';
 import Login from '../pages/Login';
 import Signup from '../pages/Signup';
+import Profile from '../pages/Profile';
 
 function App() {
   // for development, this sessionId uses localStorage and crypto
-  // in production, this should be handled by something like JWT and/or cookies
+  // in production, this should `be handled by something like JWT and/or cookies
   const [sessionId, setSessionId] = useState(localStorage.getItem('sessionId'));
   const location = useLocation();
   const navigate = useNavigate();
@@ -17,6 +18,9 @@ function App() {
   useEffect(() => {
     if (sessionId) {
       localStorage.setItem('sessionId', sessionId);
+      if (!localStorage.getItem('firstLogin')) {
+        localStorage.setItem('firstLogin', 'true');
+      }
       if (location.pathname === '/login' || location.pathname === '/register' || location.pathname === '/') {
         navigate('/events', { replace: true });
       }
@@ -51,7 +55,7 @@ function App() {
       <Route path='/' element={<div>Hello World</div>} />
       <Route path='/login' element={<Login setSessionId={setSessionId} />} />
       <Route path='/signup' element={<Signup setSessionId={setSessionId} />} />
-      <Route path='/profile' element={<div>Profile</div>} />
+      <Route path='/profile' element={<Profile activities={activities} skillLevels={skillLevels} />} />
       <Route path='/events' element={<div>Events</div>} />
       <Route path='*' element={<Navigate to={sessionId ? '/events' : '/login'} />} />
     </Routes>

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -14,5 +14,5 @@ root.render(
         <App />
       </Router>
     </MantineProvider>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,0 +1,217 @@
+// src/pages/UserProfilePage.jsx
+import React, { useState, useEffect } from 'react';
+import {
+  Alert,
+  Text,
+  Container,
+  TextInput,
+  PasswordInput,
+  Button,
+  Checkbox,
+  Slider,
+  Box,
+  Title,
+  Stack,
+  Divider,
+  Space,
+} from '@mantine/core';
+import { IconInfoCircle } from '@tabler/icons-react';
+import { useForm } from '@mantine/form';
+import PhotoPicker from '../components/PhotoPicker';
+import AddressPicker from '../components/AddressPicker';
+
+const sportsList = [
+  { key: 'pickleball', label: 'Pickleball' },
+  { key: 'ultimateFrisbee', label: 'Ultimate Frisbee' },
+  { key: 'volleyball', label: 'Volleyball' },
+  { key: 'basketball', label: 'Basketball' },
+  { key: 'kickball', label: 'Kickball' },
+];
+
+export default function Profile({ activities, skillLevels }) {
+  const [selectedSports, setSelectedSports] = useState({});
+  const [showFirstLoginMsg, setShowFirstLoginMsg] = useState(false);
+
+  useEffect(() => {
+    if (localStorage.getItem('firstLogin') === 'true') {
+      setShowFirstLoginMsg(true);
+    }
+  }, []);
+
+  const form = useForm({
+    initialValues: {
+      displayName: '',
+      firstName: '',
+      lastName: '',
+      preferredAddress: '',
+      email: '',
+      password: '',
+      photo: null,
+      sports: {},
+    },
+
+    validate: {
+      firstName: (value) => (!value ? 'First name required' : null),
+      lastName: (value) => (!value ? 'Last name required' : null),
+      preferredAddress: (value) => (!value ? 'Preferred addr' : null),
+      email: (value) => {
+        if (/^\S+@\S+$/.test(value)) {
+          return null;
+        }
+        return 'Please enter a valid email';
+      },
+      password: (value) => {
+        if (value.length < 6) {
+          return 'Password must be at least 6 characters';
+        }
+        return null;
+      },
+    },
+  });
+
+  const toggleSport = (sport) => {
+    setSelectedSports((prev) => {
+      const updated = { ...prev };
+      if (updated[sport]) {
+        delete updated[sport];
+      } else {
+        updated[sport] = 1;
+      }
+      return updated;
+    });
+  };
+
+  const handleSkillChange = (sport, value) => {
+    setSelectedSports((prev) => ({ ...prev, [sport]: value }));
+  };
+
+  const handleSubmit = (values) => {
+    if (localStorage.getItem('firstLogin') === 'true') {
+      localStorage.removeItem('firstLogin');
+      setShowFirstLoginMsg(false);
+    }
+
+    console.log('Form submitted:', { ...values, sports: selectedSports });
+  };
+
+  return (
+    <Container size={500}>
+      <Space h='lg' />
+      {showFirstLoginMsg && (
+        <Alert variant='light' color='teal' title='Info Needed' icon={<IconInfoCircle size={20} />}>
+          <Text size='xs'>Please fill out the required fields in your profile.</Text>
+        </Alert>
+      )}
+
+      <Space h='lg' />
+      <Title order={1} size='h2'>Profile</Title>
+
+      <form onSubmit={form.onSubmit(handleSubmit)}>
+        {/* User Info */}
+        <Title order={2} size='h4'>User Info</Title>
+        <Stack>
+          {/* Photo Picker */}
+          <PhotoPicker
+            value={form.values.photo}
+            onChange={(file) => form.setFieldValue('photo', file)}
+          />
+
+          {/* Display Name */}
+          <TextInput
+            label='Display Name'
+            placeholder='Enter display name'
+            {...form.getInputProps('displayName')}
+          />
+
+          {/* First Name */}
+          <TextInput
+            withAsterisk
+            label='First Name'
+            placeholder='Enter first name'
+            {...form.getInputProps('firstName')}
+          />
+
+          {/* Last Name */}
+          <TextInput
+            withAsterisk
+            label='Last Name'
+            placeholder='Enter last name'
+            {...form.getInputProps('lastName')}
+          />
+
+          {/* Preferred Address */}
+          <AddressPicker />
+        </Stack>
+
+        <Space h='md' />
+        <Divider my='sm' />
+        <Space h='md' />
+
+        {/* Activity Info */}
+        <Title order={2} mb='sm' size='h4'>Activity Info</Title>
+        <Stack>
+          {sportsList.map((sport) => (
+            <Box key={sport.key}>
+              <Checkbox
+                label={sport.label}
+                checked={!!selectedSports[sport.key]}
+                onChange={() => toggleSport(sport.key)}
+                size='xs'
+              />
+              {selectedSports[sport.key] && (
+                <Box mt='lg' mb='lg'>
+                  <Slider
+                    color='teal'
+                    size='md'
+                    min={1}
+                    max={3}
+                    step={1}
+                    value={selectedSports[sport.key]}
+                    onChange={(val) => handleSkillChange(sport.key, val)}
+                    marks={[
+                      { value: 1, label: 'Beginner' },
+                      { value: 2, label: 'Intermediate' },
+                      { value: 3, label: 'Advanced' },
+                    ]}
+                  />
+                </Box>
+              )}
+            </Box>
+          ))}
+        </Stack>
+
+        <Space h='md' />
+        <Divider my='sm' />
+        <Space h='md' />
+
+        {/* Account Info */}
+        <Title order={2} size='h4'>Account Info</Title>
+        <Stack>
+          {/* Email */}
+          <TextInput
+            withAsterisk
+            label='Primary Email'
+            placeholder='Enter email'
+            {...form.getInputProps('email')}
+          />
+
+          {/* Password */}
+          <PasswordInput
+            withAsterisk
+            label='Password'
+            placeholder='Enter password'
+            {...form.getInputProps('password')}
+          />
+        </Stack>
+
+        <Space h='md' />
+        <Divider my='sm' />
+        <Space h='md' />
+
+        <Button fullWidth type='submit'>Save Profile</Button>
+      </form>
+
+      <Space h='xl' />
+    </Container>
+  );
+}

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -20,17 +20,27 @@ import { useForm } from '@mantine/form';
 import PhotoPicker from '../components/PhotoPicker';
 import AddressPicker from '../components/AddressPicker';
 
-const sportsList = [
-  { key: 'pickleball', label: 'Pickleball' },
-  { key: 'ultimateFrisbee', label: 'Ultimate Frisbee' },
-  { key: 'volleyball', label: 'Volleyball' },
-  { key: 'basketball', label: 'Basketball' },
-  { key: 'kickball', label: 'Kickball' },
-];
-
-export default function Profile({ activities, skillLevels }) {
+export default function Profile({ activities = [], skillLevels = [] }) {
   const [selectedSports, setSelectedSports] = useState({});
   const [showFirstLoginMsg, setShowFirstLoginMsg] = useState(false);
+
+  // TODO: Remove placeholder data when backend is ready
+  const placeholderActivities = [
+    { id: '301', name: 'Pickleball' },
+    { id: '302', name: 'Volleyball' },
+    { id: '303', name: 'Basketball' },
+    { id: '304', name: 'Ultimate Frisbee' },
+    { id: '305', name: 'Kickball' },
+  ];
+
+  const placeholderSkillLevels = [
+    { id: '501', name: 'Beginner', displayOrder: 1 },
+    { id: '502', name: 'Intermediate', displayOrder: 2 },
+    { id: '503', name: 'Expert', displayOrder: 3 },
+  ];
+
+  const activitiesToUse = activities.length > 0 ? activities : placeholderActivities;
+  const skillLevelsToUse = skillLevels.length > 0 ? skillLevels : placeholderSkillLevels;
 
   useEffect(() => {
     if (localStorage.getItem('firstLogin') === 'true') {
@@ -150,15 +160,15 @@ export default function Profile({ activities, skillLevels }) {
         {/* Activity Info */}
         <Title order={2} mb='sm' size='h4'>Activity Info</Title>
         <Stack>
-          {sportsList.map((sport) => (
-            <Box key={sport.key}>
+          {activitiesToUse.map((activity) => (
+            <Box key={activity.id}>
               <Checkbox
-                label={sport.label}
-                checked={!!selectedSports[sport.key]}
-                onChange={() => toggleSport(sport.key)}
+                label={activity.name}
+                checked={!!selectedSports[activity.id]}
+                onChange={() => toggleSport(activity.id)}
                 size='xs'
               />
-              {selectedSports[sport.key] && (
+              {selectedSports[activity.id] && (
                 <Box mt='lg' mb='lg'>
                   <Slider
                     color='teal'
@@ -166,13 +176,11 @@ export default function Profile({ activities, skillLevels }) {
                     min={1}
                     max={3}
                     step={1}
-                    value={selectedSports[sport.key]}
-                    onChange={(val) => handleSkillChange(sport.key, val)}
-                    marks={[
-                      { value: 1, label: 'Beginner' },
-                      { value: 2, label: 'Intermediate' },
-                      { value: 3, label: 'Advanced' },
-                    ]}
+                    value={selectedSports[activity.key]}
+                    onChange={(val) => handleSkillChange(activity.id, val)}
+                    marks={skillLevelsToUse.map((level) => ({
+                      value: parseInt(level.displayOrder, 10), label: level.name,
+                    }))}
                   />
                 </Box>
               )}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@mantine/form": "^8.3.1",
     "@mantine/hooks": "^8.3.1",
     "@phosphor-icons/react": "^2.1.10",
+    "@tabler/icons-react": "^3.34.1",
     "axios": "^1.12.1",
     "dotenv": "^17.2.2",
     "express": "^4.21.2",


### PR DESCRIPTION
This adds the profile page UI and incorporates 2 of @eddie-nv shared components (**AddressPicker**, **PhotoPicker**). I will eventually need to update AddressPicker to have error handling (and also pass its selected value to the parent, I believe).

Nothing is really wired yet - that will be a separate ticket (hardcoded placeholders will need to be removed & refactored). 

Suggest temporarily removing height: 100%; from the body/html css since this was the only way I could get the page elements to expand correctly, but I'm open to other ideas! 

Also adding @tabler/icons-react to our dependencies for an icon library! 